### PR TITLE
Add/drag and drop

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -29,7 +29,16 @@ class MemosController < ApplicationController
     end
   end
 
-  def update; end
+  def update
+    Rails.logger.debug 'updateメソッドが呼ばれました'
+    @memo = Memo.find(params[:id])
+    Rails.logger.debug { "update_component_params: #{update_component_params}" }
+    if @memo.update(memo_components: update_component_params)
+      render json: { message: 'update successfully' }, status: :ok
+    else
+      render json: { message: 'update failed' }, status: :unprocessable_entity
+    end
+  end
 
   def destroy; end
 
@@ -37,6 +46,10 @@ class MemosController < ApplicationController
 
   def memo_params
     params.require(:memo).except(:lyrics).permit(:song_title, :artist_name)
+  end
+
+  def update_component_params
+    params.require(:memo_components)
   end
 
   def fetch_lyrics(api_key, q_track, q_artist)

--- a/app/javascript/components/Memos.jsx
+++ b/app/javascript/components/Memos.jsx
@@ -11,21 +11,28 @@ export default function Memos({ memo_components }) {
     setComponents(memo_components);
   }, [memo_components]);
   
+  const addComponent = () => {
+    const componentId = components.length + 1;
+    setComponents([...components, { x: 100, y: 100, id: componentId, content: `New Component ${componentId}`}])
+  }
   return (
     <>
-      <div className="bg-red-200">
-
-        {components?.map((component) => (
-          <Draggable
-            key={component.id}
-            position={{ x: component.x, y: component.y}}
-            bounds="parent"
-          >
-            <div className="bg-white p-2 border border-gray-300 rounded-md shadow-md">
-              {component.content}
-            </div>
-          </Draggable>
-        ))}
+      <div className="relative">
+        <div className="absolute top-0 left-0 w-full">
+          <button onClick={addComponent} className="btn">コンポーネントを追加</button>
+          {components?.map((component) => (
+            <Draggable
+              key={component.id}
+              position={{ x: component.x, y: component.y}}
+              bouds="parent"
+            >
+              <div className="component bg-white border border-gray-300 rounded-md shadow-md p-2 
+              max-w-xs w-fit whitespace-normal break-words flex items-center justify-center absolute">
+                {component.content}
+              </div>
+            </Draggable>
+            ))}
+        </div>
       </div>
     </>
   );

--- a/app/javascript/components/Memos.jsx
+++ b/app/javascript/components/Memos.jsx
@@ -1,29 +1,72 @@
 import React, { useState, useEffect } from "react";
 import Draggable from "react-draggable";
+import axios from "axios";
 
-export default function Memos({ memo_components }) {
+export default function Memos({ memo }) {
+  console.log("memo", memo);
   const [components, setComponents] = useState([]);
   const [selectedComponent, setSelectedComponent] = useState(null);
   const [componentGroups, setComponentGroups] = useState([]);
 
-  console.log("memo_components", memo_components);
+  
   useEffect(() => {
-    setComponents(memo_components);
-  }, [memo_components]);
+    setComponents(memo.memo_components);
+  }, [memo]);
+
+  useEffect(() => {
+    console.log("components", components);
+  }, [components]);
   
   const addComponent = () => {
     const componentId = components.length + 1;
-    setComponents([...components, { x: 100, y: 100, id: componentId, content: `New Component ${componentId}`}])
+    setComponents([...components, { x: 100, y: 100, id: componentId, type: "technique", content: `New Component ${componentId}`}])
   }
+
+  const updatePosition = (id, data) => {
+    const UpdateComponent = components.map((component)=>{
+      if(component.id === id){
+        return {
+          ...component,
+            id: component.id,
+            x: data.x,
+            y: data.y
+        }
+      }
+      return component;
+    });
+    setComponents(UpdateComponent);
+  }
+
+  const saveComponents = async() => {
+    try {
+      const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
+
+      const response = await axios.patch(`/memos/${memo.id}`, {
+        memo_components: components,
+      }, {
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": csrfToken,
+        },
+      });
+      console.log("Success:", response.data);
+    } catch (error) {
+      console.error("Error:", error);
+    }
+  }
+
   return (
     <>
       <div className="relative">
+
         <div className="absolute top-0 left-0 w-full">
           <button onClick={addComponent} className="btn">コンポーネントを追加</button>
+          <button onClick={saveComponents} className="btn">保存</button>
           {components?.map((component) => (
             <Draggable
               key={component.id}
               position={{ x: component.x, y: component.y}}
+              onStop={(e, data) => updatePosition(component.id, data)}
               bouds="parent"
             >
               <div className="component bg-white border border-gray-300 rounded-md shadow-md p-2 

--- a/app/javascript/components/Memos.jsx
+++ b/app/javascript/components/Memos.jsx
@@ -22,6 +22,10 @@ export default function Memos({ memo }) {
     setComponents([...components, { x: 100, y: 100, id: componentId, type: "technique", content: `New Component ${componentId}`}])
   }
 
+  const deleteComponent = (id) => {
+    setComponents(components.filter(component => component.id !== id))
+  }
+
   const updatePosition = (id, data) => {
     const UpdateComponent = components.map((component)=>{
       if(component.id === id){
@@ -69,9 +73,39 @@ export default function Memos({ memo }) {
               onStop={(e, data) => updatePosition(component.id, data)}
               bouds="parent"
             >
-              <div className="component bg-white border border-gray-300 rounded-md shadow-md p-2 
-              max-w-xs w-fit whitespace-normal break-words flex items-center justify-center absolute">
-                {component.content}
+              <div>
+                <div className="component bg-white border border-gray-300 rounded-md shadow-md p-2 
+                max-w-xs w-fit whitespace-normal break-words flex items-center justify-center absolute flex flex-col"
+                     onClick={(e) => {
+                      e.stopPropagation();
+                      setSelectedComponent(component.id);
+                     }}
+                     onTouchStart={(e) => {
+                      e.stopPropagation();
+                      setSelectedComponent(component.id);
+                     }}
+                >
+                  <div>
+                    {selectedComponent === component.id && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          deleteComponent(component.id);
+                        }}
+                        onTouchStart={(e) => {
+                          e.stopPropagation();
+                          deleteComponent(component.id);
+                        }}
+                      >
+                        ✕
+                      </button>
+
+                    )}
+                  </div>
+                  <div>
+                    {component.content}                   
+                  </div>
+                </div>
               </div>
             </Draggable>
             ))}

--- a/app/javascript/components/Memos.jsx
+++ b/app/javascript/components/Memos.jsx
@@ -54,13 +54,37 @@ export default function Memos({ memo }) {
         },
       });
       console.log("Success:", response.data);
+      console.log("status:", response.status);
+
+      // 保存成功時フラッシュメッセージ
+      const flashmessage = document.getElementById("flash-message");
+      flashmessage.innerHTML = "保存しました";
+      flashmessage.classList.remove("hidden");
+      flashmessage.classList.add("bg-green-600");
+      setTimeout(() => {
+        flashmessage.classList.add("hidden");
+        flashmessage.classList.remove("bg-green-600");
+      }, 3000);
+
     } catch (error) {
       console.error("Error:", error);
+      console.log("status:", response.status);
+
+      // 保存失敗時フラッシュメッセージ
+      const flashmessage = document.getElementById("flash-message");
+      flashmessage.innerHTML = "保存に失敗しました";
+      flashmessage.classList.remove("hidden");
+      flashmessage.classList.add("bg-red-600");
+      setTimeout(() => {
+        flashmessage.classList.add("hidden");
+        flashmessage.classList.remove("bg-red-600");
+      }, 3000);
     }
   }
 
   return (
     <>
+      <div id="flash-message" className="hidden bg-white p-2 w-full">あいうえお</div>
       <div className="relative">
 
         <div className="absolute top-0 left-0 w-full">

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -1,14 +1,14 @@
-<div>
+<div class="bg-red-200">
   <p>artist_name: <%= @memo[:artist_name] %></p>
   <p>titile: <%= @memo[:song_title] %></p>
+  <%= react_component("Memos", memo_components: @memo[:memo_components], data: { turbo: false })%>
+  <% if @lyrics_result %>
+    <div class="mx-5 mt-10 mb-10 pt-10"><%= simple_format(h(@lyrics_result)) %></div>
+    <div class="text-white font-bold text-3xl py-10 m-10">
+    ごめんねー！ライセンスの関係で歌詞ここまでしか取れないんだよね！！
+    </div>
+  <% else %>
+    あれ、なんで取れないんだろうね。。。
+  <% end %>
 </div>
-<%= react_component("Memos", memo_components: @memo[:memo_components], data: { turbo: false })%>
 
-<% if @lyrics_result %>
-  <div class="mx-5 mt-10 mb-10 pt-10"><%= simple_format(h(@lyrics_result)) %></div>
-  <div class="text-white font-bold text-3xl py-10 m-10">
-  ごめんねー！ライセンスの関係で歌詞ここまでしか取れないんだよね！！
-  </div>
-<% else %>
-  あれ、なんで取れないんだろうね。。。
-<% end %>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-red-200">
   <p>artist_name: <%= @memo[:artist_name] %></p>
   <p>titile: <%= @memo[:song_title] %></p>
-  <%= react_component("Memos", memo_components: @memo[:memo_components], data: { turbo: false })%>
+  <%= react_component("Memos", {memo: @memo.as_json(only:[:id, :memo_components])}, data: { turbo: false })%>
   <% if @lyrics_result %>
     <div class="mx-5 mt-10 mb-10 pt-10"><%= simple_format(h(@lyrics_result)) %></div>
     <div class="text-white font-bold text-3xl py-10 m-10">

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/babel__core": "7",
     "@types/webpack": "5",
     "autoprefixer": "^10.4.16",
+    "axios": "^1.8.1",
     "babel-loader": "8",
     "compression-webpack-plugin": "9",
     "css-loader": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2247,6 +2247,15 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
+axios@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.1.tgz#7c118d2146e9ebac512b7d1128771cdd738d11e3"
+  integrity sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
@@ -3881,7 +3890,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.15.6:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
@@ -6400,6 +6409,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.15.0"


### PR DESCRIPTION
## 概要
- メモ作成画面でコンポーネントを表示し、ドラッグ＆ドロップし、保存できる機能を実装

## 変更内容
- **新規追加**: メモ作成画面のコンポーネント複製機能追加
- **新規追加**: ドラッグ&ドロップとコンポーネント座標保存の機能を追加
- **新規追加**: コンポーネント削除ボタンの追加

## 動作確認方法
1. **Renderコンソール**
   - [x] エラーが出ていないことを確認
2. **ステージング環境**
   - [x] エラーが出ていないことを確認
   - [x] ボタン押下でコンポーネントが複製されることを確認 
   - [x] コンポーネントがドラッグ&ドロップで移動できることを確認
   - [x] コンポーネントを削除できることを確認
   - [x] 保存ボタンで現在位置が保存され、再読み込みしても同じ位置に描画されることを確認
   - [x] 保存時にフラッシュメッセージが出ることを確認

## 関連Issue
- #32 

## スクリーンショット
- iPhoneSE（ステージング環境）コンポーネント描画
![utamemo onrender com_memos_1(iPhone SE) (1)](https://github.com/user-attachments/assets/99cb7815-dfd1-41f0-8a62-071e5cf69b19)

- iPhoneSE（ステージング環境）コンポーネント移動＆保存＆フラッシュメッセージ
![utamemo onrender com_memos_1(iPhone SE) (3)](https://github.com/user-attachments/assets/d517a755-59ba-4d05-9bdb-ef4aaf98b0e5)

- iPhoneSE（ステージング環境）コンポーネント削除
![utamemo onrender com_memos_1(iPhone SE) (4)](https://github.com/user-attachments/assets/83510855-b8e2-41a9-b181-4b43c61155c8)

## 参考資料
- issueに記載

## 備考
