### PR TITLE
Add/new memo preview

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -23,8 +23,7 @@ class MemosController < ApplicationController
     @memo = Memo.new(memo_params)
     @memo.user_id = current_user.id
     if @memo.save
-      redirect_to memo_path(id: 1), data: { turbo: false }
-      # redirect_to memo_path(@memo, title: @memo.song_title, artist_name: @memo.artist_name)
+      redirect_to memo_path(id: @memo.id), data: { turbo: false }
     else
       render 'musixmatch/search', alert: 'メモの開始に失敗しました。'
     end

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -9,8 +9,7 @@ class MemosController < ApplicationController
 
   def show
     request.format = :html # turboを無効化
-    # @memo = Memo.find(params[:id])
-    @memo = Memo.first
+    @memo = Memo.find(params[:id])
 
     api_key = Rails.application.credentials[:musixmatch_api_key]
     title = @memo[:song_title]

--- a/app/javascript/components/Memos.jsx
+++ b/app/javascript/components/Memos.jsx
@@ -8,13 +8,6 @@ export default function Memos({ memo }) {
   const [selectedComponent, setSelectedComponent] = useState(null);
   const [inputType, setInputType] = useState("technique");
 
-  // 試しに消して、useStateの初期値に入れてみる。本番環境で問題なければそっちに変更。
-  // useEffect(() => {
-  //   setComponents(memo.memo_components);
-  // }, [memo]);
-
-
-
   useEffect(() => {
     console.log("components", components);
   }, [components]);
@@ -22,31 +15,46 @@ export default function Memos({ memo }) {
   // 入力モード変更
   useEffect(() => {
     console.log("inputType", inputType);
-    let target_button;
-    let no_target_button;
-    let target;
-    let no_target;
+    let technique_button = document.getElementById("technique_button");
+    let technique = document.getElementById("technique");
+    let comment_button =  document.getElementById("comment_button");
+    let comment = document.getElementById("comment");
+    let preview_button = document.getElementById("preview_button");
 
-    if (inputType === "technique"){
-      target_button = document.getElementById("technique_button")
-      no_target_button = document.getElementById("comment_button")
-      target = document.getElementById("technique")
-      no_target = document.getElementById("comment")
-    }else if (inputType === "comment"){
-      target_button = document.getElementById("comment_button")
-      no_target_button = document.getElementById("technique_button")
-      target = document.getElementById("comment")
-      no_target = document.getElementById("technique")
+    switch (inputType) {
+      case "technique":
+        technique_button.classList.remove("bg-gray-300")
+        technique_button.classList.add("bg-red-300")
+        technique.classList.remove("hidden")
+        comment_button.classList.remove("bg-red-300")
+        comment_button.classList.add("bg-gray-300")
+        comment.classList.add("hidden")
+        preview_button.classList.remove("bg-red-300")
+        preview_button.classList.add("bg-gray-300")
+        break;
+      case "comment":
+        comment_button.classList.remove("bg-gray-300")
+        comment_button.classList.add("bg-red-300")
+        comment.classList.remove("hidden")
+        technique_button.classList.remove("bg-red-300")
+        technique_button.classList.add("bg-gray-300")
+        technique.classList.add("hidden")
+        preview_button.classList.remove("bg-red-300")
+        preview_button.classList.add("bg-gray-300")
+        break;
+      case "preview":
+        preview_button.classList.remove("bg-gray-300")
+        preview_button.classList.add("bg-red-300")
+        technique_button.classList.remove("bg-red-300")
+        technique_button.classList.add("bg-gray-300")
+        technique.classList.add("hidden")
+        comment_button.classList.remove("bg-red-300")
+        comment_button.classList.add("bg-gray-300")
+        comment.classList.add("hidden")
+        break;
+      default:
+        console.log("inputTypeが見つかりません")
     }
-    // モード切り替え
-    target.classList.remove("hidden")
-    no_target.classList.add("hidden")
-    
-    // ボタン色切り替え
-    target_button.classList.remove("bg-gray-300")
-    target_button.classList.add("bg-red-300")
-    no_target_button.classList.remove("bg-red-300")
-    no_target_button.classList.add("bg-gray-300")
   },[inputType]);
 
   // テクニックコンポーネント追加
@@ -58,8 +66,9 @@ export default function Memos({ memo }) {
   // コメントコンポーネント追加
   const addCommentComponent = () => {
     const componentId = components.length + 1;
-    const comment = document.getElementById("comment_input").value
-    setComponents([...components, { x: 100, y: 100, id: componentId, type: "comment", content: comment}])
+    const comment = document.getElementById("comment_input")
+    setComponents([...components, { x: 100, y: 100, id: componentId, type: "comment", content: comment.value}])
+    comment.value = ""
   }
 
   // コンポーネント削除
@@ -141,6 +150,12 @@ export default function Memos({ memo }) {
           }
           id = "comment_button"
         >コメント</button>
+        <button 
+          className="btn bg-gray-300"
+          onClick={() => setInputType("preview")
+          }
+          id = "preview_button"
+        >プレビュー</button>
         <button onClick={saveComponents} className="btn">保存</button>
       </div>
 

--- a/app/javascript/components/MyMemos.jsx
+++ b/app/javascript/components/MyMemos.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import Draggable from "react-draggable";
 import axios from "axios";
 
-export default function Memos({ memo }) {
+export default function MyMemos({ memo }) {
   console.log("memo", memo);
   const [components, setComponents] = useState(memo.memo_components);
   const [selectedComponent, setSelectedComponent] = useState(null);
@@ -136,6 +136,7 @@ export default function Memos({ memo }) {
 
   return (
     <>
+      <div>MyMemos.jsx</div>
       {/* ツールバー  */}
       <div className="p-5 flex flex-row between space-x-2">
         <button

--- a/app/javascript/components/OtherMemos.jsx
+++ b/app/javascript/components/OtherMemos.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+export default function OtherMemos({ memo }) {
+
+  return (
+    <>
+      <div>OtherMemos</div>
+      {/* コンポーネント配置 */}
+      <div className="relative">
+        <div className="absolute top-0 left-0 w-full">
+          {memo.memo_components?.map((component) => (
+            <div
+            key={component.id}
+            className="absolute bg-white border border-gray-300 rounded-md shadow-md p-2"
+            style={{
+              left: `${component.x}px`,  // x座標
+              top: `${component.y}px`,   // y座標
+            }}
+            >
+              {component.content}
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -1,7 +1,6 @@
-  <div class="p-4 pb-2 text-xs opacity-60 tracking-wide">新着メモ一覧</div>
+<div class="p-4 pb-2 text-xs opacity-60 tracking-wide">新着メモ一覧</div>
 <% @memos.each do |memo| %>
-  <ul class="list bg-base-100 rounded-box shadow-md p-4 mb-4 mx-4">    
-    <li class="list-row">
+  <%= button_to memo_path(memo.id), { method: :get, class: "list w-full bg-base-100 rounded-box shadow-md p-4 mb-4" } do %>    
       <div class="flex flex-row items-center justify-between">
         <div>
           <img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/1@94.webp"/>
@@ -11,9 +10,9 @@
           <div class="text-xs uppercase font-semibold opacity-60"><%= memo[:song_title] %> : <%= memo[:artist_name] %></div>
         </div>
         <div>
-          <button class="btn btn-square btn-ghost">
+          <div class="btn btn-square btn-ghost">
             <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor"><path d="M6 3L20 12 6 21 6 3z"></path></g></svg>
-          </button>
+          </div>
           <!-- お気に入りマーク
           <button class="btn btn-square btn-ghost">
             <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor"><path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"></path></g></svg>
@@ -21,6 +20,5 @@
           -->
         </div>
       </div>
-    </li>    
-  </ul>
+  <% end %>
 <% end %>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -1,7 +1,12 @@
 <div class="bg-red-200">
   <p>artist_name: <%= @memo[:artist_name] %></p>
   <p>titile: <%= @memo[:song_title] %></p>
-  <%= react_component("Memos", {memo: @memo.as_json(only:[:id, :memo_components])}, data: { turbo: false })%>
+  <p>created_by: <%= @memo.user[:nickname] %></p>
+  <% if !!current_user && current_user.id == @memo.user_id %>
+    <%= react_component("MyMemos", {memo: @memo.as_json(only:[:id, :memo_components])}, data: { turbo: false })%>
+  <% else %>
+    <%= react_component("OtherMemos", {memo: @memo.as_json(only:[:id, :memo_components])}, data: { turbo: false })%>
+  <% end %>
   <% if @lyrics_result %>
     <div class="mx-5 mt-10 mb-10 pt-10"><%= simple_format(h(@lyrics_result)) %></div>
     <div class="text-white font-bold text-3xl py-10 m-10">


### PR DESCRIPTION
## 概要
- 新着メモ一覧画面からメモプレビュー画面への導線と、ログインユーザーによってツールバーを表示するか否かの分岐を実装

## 変更内容
- **新規追加**: 他ユーザーのメモを一覧するときに使用するコンポーネントを追加（OtherMemos.jsx）
- **修正**: メモ一覧画面からメモプレビュー画面への遷移を実装

## 動作確認方法
1. **Renderコンソール**
   - [x] エラーが出ていないことを確認
2. **ステージング環境**
   - [x] エラーが出ていないことを確認
   - [x] ログインユーザーによってツールバーの表示有無を切り替えられていることを確認 

## 関連Issue
- #36 

## スクリーンショット
- iPhoneSE（ステージング環境）自分のメモプレビュー
![utamemo onrender com_memos_29(iPhone SE) (3)](https://github.com/user-attachments/assets/cced9498-3d40-4fed-9a0b-38e0eca7c8b5)


- iPhoneSE（ステージング環境）他人のメモプレビュー
![utamemo onrender com_memos_29(iPhone SE)](https://github.com/user-attachments/assets/65dc2b37-b1d0-4569-ac01-5780275e3bd6)

## 参考資料
- issueに記載

## 備考
