### PR TITLE
add:マイページの追加

### DIFF
--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MypageController < ApplicationController
   def index
     @my_memos = current_user.memos.order(created_at: :desc)

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -1,0 +1,5 @@
+class MypageController < ApplicationController
+  def index
+    @my_memos = current_user.memos.order(created_at: :desc)
+  end
+end

--- a/app/helpers/mypage_helper.rb
+++ b/app/helpers/mypage_helper.rb
@@ -1,0 +1,2 @@
+module MypageHelper
+end

--- a/app/helpers/mypage_helper.rb
+++ b/app/helpers/mypage_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module MypageHelper
 end

--- a/app/views/mypage/index.html.erb
+++ b/app/views/mypage/index.html.erb
@@ -1,0 +1,20 @@
+<div class="text-3xl text-center">ニックネーム: <%= current_user.nickname %></div>
+<div class="p-4 pb-2 text-xs opacity-60 tracking-wide">マイメモ一覧</div>
+<% @my_memos.each do |my_memo| %>
+  <%= button_to memo_path(my_memo.id), { method: :get, class: "list w-full bg-base-100 rounded-box shadow-md p-4 mb-4" } do %>    
+      <div class="flex flex-row items-center justify-between">
+        <div>
+          <img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/1@94.webp"/>
+        </div>
+        <div>
+          <div><%= my_memo.user.nickname %></div>
+          <div class="text-xs uppercase font-semibold opacity-60"><%= my_memo[:song_title] %> : <%= my_memo[:artist_name] %></div>
+        </div>
+        <div>
+          <div class="btn btn-square btn-ghost">
+            <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor"><path d="M6 3L20 12 6 21 6 3z"></path></g></svg>
+          </div>
+        </div>
+      </div>
+  <% end %>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -53,15 +53,17 @@
     >
       <% if user_signed_in? %>
         <li><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete}, class: "block px-4 py-2 hover:bg-blue-600" %></li>
-        <li><%= link_to "マイページ", "#", class: "block px-4 py-2 hover:bg-blue-600" %></li>
+        <li><%= link_to "マイページ", mypage_index_path, class: "block px-4 py-2 hover:bg-blue-600" %></li>
       <% else %>
         <li><%= link_to "ログイン", new_user_session_path, class: "block px-4 py-2 hover:bg-blue-600" %></li>
         <li><%= link_to "新規会員登録", new_user_registration_path, class: "block px-4 py-2 hover:bg-blue-600" %></li>
       <% end %>
       <li><%= link_to "新着メモ", memos_path, class: "block px-4 py-2 hover:bg-blue-600" %></li>
+      <!--
       <li><%= link_to "お問い合わせ", "#", class: "block px-4 py-2 hover:bg-blue-600" %></li>
       <li><%= link_to "利用規約", "#", class: "block px-4 py-2 hover:bg-blue-600" %></li>
       <li><%= link_to "プライバシーポリシー", "#", class: "block px-4 py-2 hover:bg-blue-600" %></li>
+      -->
     </ul>
   </div>
 </header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,12 +2,13 @@
 
 Rails.application.routes.draw do
   resources :memos, only: %i[index show create update destroy]
-  get 'musixmatch/search'
   devise_for :users
   get 'up' => 'rails/health#show', as: :rails_health_check
-
+  
   get 'service-worker' => 'rails/pwa#service_worker', as: :pwa_service_worker
   get 'manifest' => 'rails/pwa#manifest', as: :pwa_manifest
-
+  get 'musixmatch/search'
+  resources :mypage, only: %i(index)
+  
   root 'top#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,11 @@ Rails.application.routes.draw do
   resources :memos, only: %i[index show create update destroy]
   devise_for :users
   get 'up' => 'rails/health#show', as: :rails_health_check
-  
+
   get 'service-worker' => 'rails/pwa#service_worker', as: :pwa_service_worker
   get 'manifest' => 'rails/pwa#manifest', as: :pwa_manifest
   get 'musixmatch/search'
-  resources :mypage, only: %i(index)
-  
+  resources :mypage, only: %i[index]
+
   root 'top#index'
 end

--- a/test/controllers/mypage_controller_test.rb
+++ b/test/controllers/mypage_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class MypageControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get mypage_index_url
+    assert_response :success
+  end
+end

--- a/test/controllers/mypage_controller_test.rb
+++ b/test/controllers/mypage_controller_test.rb
@@ -1,7 +1,9 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class MypageControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
+  test 'should get index' do
     get mypage_index_url
     assert_response :success
   end


### PR DESCRIPTION
## 概要
- マイページを追加し、自分の作成したメモを閲覧できるよう実装した。

## 変更内容
- **新規追加**: マイページを追加。自分の作成したメモを閲覧できる。
- **修正**: メモ作成時にメモid１に飛ばすようにしていたので、作成したメモに遷移するように修正。

## 動作確認方法
1. **Renderコンソール**
   - [x] エラーが出ていないことを確認
2. **ステージング環境**
   - [x] エラーが出ていないことを確認
   - [x] マイページに遷移できることを確認
   - [x] マイページのメモ一覧に他人のメモが無いことを確認
   - [x] マイページのメモ一覧からメモ作成画面に遷移できることを確認 

## 関連Issue
- #

## スクリーンショット
- iPhoneSE（ステージング環境）マイページ
![utamemo onrender com_mypage(iPhone SE)](https://github.com/user-attachments/assets/98b573ad-b0e8-4c14-af56-45859d0abc7d)

- iPhoneSE（ステージング環境）遷移後のメモ作成画面
![utamemo onrender com_memos_29(iPhone SE) (4)](https://github.com/user-attachments/assets/ebc2d86f-d931-4bb5-9c5a-888d54999410)

## 参考資料
- issueに記載

## 備考
