### PR TITLE
Fix/bug

### DIFF
--- a/app/views/memos/_favorite.html.erb
+++ b/app/views/memos/_favorite.html.erb
@@ -1,6 +1,6 @@
   <% if current_user && memo.favorited_by?(current_user) %>
     <%= link_to memo_favorite_path(memo.id, memo.favorites.find_by(user_id: current_user.id).id), data: {turbo_method: :delete} do %>
-      <div class="md:flex md:flex-row md:items-center md:justify-center md:space-x-2">
+      <div class="flex flex-row items-center justify-center space-x-1">
         <i class="fa-solid fa-heart text-pink-500"></i>
         <div>
           <%= memo.favorites.count %>
@@ -9,7 +9,7 @@
     <% end %>
   <% else %>
     <%= link_to memo_favorites_path(memo.id), data: {turbo_method: :post} do %>
-      <div class="md:flex md:flex-row md:items-center md:justify-center md:space-x-2">
+      <div class="flex flex-row items-center justify-center space-x-1">
         <i class="fa-regular fa-heart"></i>
         <div>
           <%= memo.favorites.count %>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -2,19 +2,24 @@
 <div class="p-4 text-3xl text-white font-bold text-center">新着メモ一覧</div>
 <div class="p-4 flex flex-col items-center space-y-2">
   <% @memos.each do |memo| %>
-    <div class="items-center w-[330px] md:w-[1000px] mx-auto">
+    <div class="items-center w-[330px] md:w-[800px] mx-auto">
       <%= button_to memo_path(memo.id), { method: :get, class: "w-full mx-auto bg-base-100 rounded-box shadow-md p-4" } do %>    
-        <div class="flex flex-row justify-center items-center">
-          <div>
-            <% if memo.user.profile&.image&.attached? %>
-              <%= image_tag memo.user.profile.image, size: "100x100", class: "rounded-box" %>
-            <% else %>
-              <%= image_tag "アイコン_デフォルト.png", size: "100x100", class: "rounded-box" %>
-            <% end %>
-          </div>
-          <div class="md:flex md:flex-row md:items-center md:justify-center md:space-x-10 w-full md:w-1/2">
-            <div class="text-xl font-bold md:text-2xl"><%= memo.user.nickname %></div>
-            <div class="uppercase font-semibold opacity-60 md:text-2xl"><%= memo[:artist_name] %> <br> <%= memo[:song_title] %></div>
+        <div class="flex flex-row items-center justify-between">
+          <div class="flex flex-row items-center space-x-5 md:space-x-10">
+            <div>
+              <% if memo.user.profile&.image&.attached? %>
+                <%= image_tag memo.user.profile.image, size: "70x70", class: "rounded-box" %>
+              <% else %>
+                <%= image_tag "アイコン_デフォルト.png", size: "70x70", class: "rounded-box" %>
+              <% end %>
+            </div>
+            <div class="md:flex md:flex-row md:items-center md:justify-center md:space-x-30">
+              <div class="text-xl font-bold md:text-2xl"><%= memo.user.nickname %></div>
+              <div>
+                <div class="uppercase font-semibold opacity-60 md:text-2xl"><%= memo[:artist_name] %></div>
+                <div class="uppercase font-semibold opacity-60 md:text-2xl"><%= memo[:song_title] %></div>
+              </div>
+            </div>
           </div>
           <div id="memo_<%= memo.id %>_favorite" class="text-2xl">
             <%= render "memos/favorite", memo: memo %>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -5,7 +5,7 @@
     <% @memos.each do |memo| %>
       <div class="items-center w-full mx-auto">
         <%= button_to memo_path(memo.id), { method: :get, class: "w-full mx-auto bg-base-100 rounded-box shadow-md p-4" } do %>    
-          <div class="flex flex-row items-center">
+          <div class="flex flex-row justify-center items-center">
             <div>
               <% if memo.user.profile&.image&.attached? %>
                 <%= image_tag memo.user.profile.image, size: "100x100", class: "rounded-box" %>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -5,7 +5,7 @@
     <div class="items-center w-[330px] md:w-[800px] mx-auto">
       <%= button_to memo_path(memo.id), { method: :get, class: "w-full mx-auto bg-base-100 rounded-box shadow-md p-4" } do %>    
         <div class="flex flex-row items-center justify-between">
-          <div class="flex flex-row items-center space-x-5 md:space-x-10">
+          <div class="flex flex-row items-center md:space-x-10">
             <div>
               <% if memo.user.profile&.image&.attached? %>
                 <%= image_tag memo.user.profile.image, size: "70x70", class: "rounded-box" %>
@@ -13,11 +13,11 @@
                 <%= image_tag "アイコン_デフォルト.png", size: "70x70", class: "rounded-box" %>
               <% end %>
             </div>
-            <div class="md:flex md:flex-row md:items-center md:justify-center md:space-x-30">
-              <div class="text-xl font-bold md:text-2xl"><%= memo.user.nickname %></div>
+            <div class="md:flex md:flex-row md:items-center">
+              <div class="text-xl font-bold md:text-2xl w-[250px] text-start"><%= memo.user.nickname %></div>
               <div>
-                <div class="uppercase font-semibold opacity-60 md:text-2xl"><%= memo[:artist_name] %></div>
-                <div class="uppercase font-semibold opacity-60 md:text-2xl"><%= memo[:song_title] %></div>
+                <div class="uppercase font-semibold opacity-60 md:text-2xl text-start"><%= memo[:artist_name] %></div>
+                <div class="uppercase font-semibold opacity-60 md:text-2xl text-start"><%= memo[:song_title] %></div>
               </div>
             </div>
           </div>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -4,7 +4,7 @@
   <div class="p-4 flex flex-col items-center space-y-2">
     <% @memos.each do |memo| %>
       <div class="items-center w-full mx-auto">
-        <%= button_to memo_path(memo.id), { method: :get, class: "w-full md:w-1/2 mx-auto bg-base-100 rounded-box shadow-md p-4" } do %>    
+        <%= button_to memo_path(memo.id), { method: :get, class: "w-full mx-auto bg-base-100 rounded-box shadow-md p-4" } do %>    
           <div class="flex flex-row items-center">
             <div>
               <% if memo.user.profile&.image&.attached? %>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -1,28 +1,26 @@
 <% provide(:title, "新着メモ一覧 | UTAMEMO")%>
 <div class="p-4 text-3xl text-white font-bold text-center">新着メモ一覧</div>
-<div class="w-full md:px-20">
-  <div class="p-4 flex flex-col items-center space-y-2">
-    <% @memos.each do |memo| %>
-      <div class="items-center w-full mx-auto">
-        <%= button_to memo_path(memo.id), { method: :get, class: "w-full mx-auto bg-base-100 rounded-box shadow-md p-4" } do %>    
-          <div class="flex flex-row justify-center items-center">
-            <div>
-              <% if memo.user.profile&.image&.attached? %>
-                <%= image_tag memo.user.profile.image, size: "100x100", class: "rounded-box" %>
-              <% else %>
-                <%= image_tag "アイコン_デフォルト.png", size: "100x100", class: "rounded-box" %>
-              <% end %>
-            </div>
-            <div class="md:flex md:flex-row md:items-center md:justify-center md:space-x-10 w-full md:w-1/2">
-              <div class="text-xl font-bold md:text-2xl"><%= memo.user.nickname %></div>
-              <div class="uppercase font-semibold opacity-60 md:text-2xl"><%= memo[:artist_name] %> <br> <%= memo[:song_title] %></div>
-            </div>
-            <div id="memo_<%= memo.id %>_favorite" class="text-2xl">
-              <%= render "memos/favorite", memo: memo %>
-            </div>
+<div class="p-4 flex flex-col items-center space-y-2">
+  <% @memos.each do |memo| %>
+    <div class="items-center w-[330px] md:w-[1000px] mx-auto">
+      <%= button_to memo_path(memo.id), { method: :get, class: "w-full mx-auto bg-base-100 rounded-box shadow-md p-4" } do %>    
+        <div class="flex flex-row justify-center items-center">
+          <div>
+            <% if memo.user.profile&.image&.attached? %>
+              <%= image_tag memo.user.profile.image, size: "100x100", class: "rounded-box" %>
+            <% else %>
+              <%= image_tag "アイコン_デフォルト.png", size: "100x100", class: "rounded-box" %>
+            <% end %>
           </div>
-        <% end %>
-      </div>           
-    <% end %>
-  </div>
+          <div class="md:flex md:flex-row md:items-center md:justify-center md:space-x-10 w-full md:w-1/2">
+            <div class="text-xl font-bold md:text-2xl"><%= memo.user.nickname %></div>
+            <div class="uppercase font-semibold opacity-60 md:text-2xl"><%= memo[:artist_name] %> <br> <%= memo[:song_title] %></div>
+          </div>
+          <div id="memo_<%= memo.id %>_favorite" class="text-2xl">
+            <%= render "memos/favorite", memo: memo %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -8,11 +8,7 @@
     <div class="mt-2 flex flex-row space-x-2 items-center">
       <% if @memo.publish %>
         <% twitter_share_url = 
-          "https://twitter.com/intent/tweet?url=#{URI.encode_www_form_component(memo_url(@memo))}
-          &text=#{@memo.user.nickname}さんのUTAMEMO！
-          &hashtags=#{remove_invalid_chars(@memo[:artist_name])},
-          #{remove_invalid_chars(@memo[:song_title])},
-          UTAMEMO"%>
+          "https://twitter.com/intent/tweet?url=#{URI.encode_www_form_component(memo_url(@memo))}&text=#{@memo.user.nickname}さんのUTAMEMO！&hashtags=#{remove_invalid_chars(@memo[:artist_name])},#{remove_invalid_chars(@memo[:song_title])},UTAMEMO" %>
           
         <%= link_to twitter_share_url,
           target: "_blank",

--- a/app/views/profiles/my_memos.html.erb
+++ b/app/views/profiles/my_memos.html.erb
@@ -4,21 +4,22 @@
 <div class="md:px-20">
   <div class="p-4 text-center flex flex-col items-center space-y-3">
     <% @my_memos.each do |my_memo| %>
-      <div class="flex flex-row w-full items-center space-x-2">
-        <div class="w-full">
+      <div class="flex flex-row w-full items-center justify-center space-x-2">
+        <div class="w-[280px] md:w-[800px]">
           <%= button_to memo_path(my_memo.id),
                         { method: :get, class: "list block w-full bg-base-100 rounded-box shadow-md p-3" } do %>    
-              <div class="flex flex-row items-center">
+              <div class="flex flex-row items-center md:space-x-20">
                 <div>
                   <% if my_memo.user.profile&.image&.attached? %>
-                    <%= image_tag my_memo.user.profile.image, class: "rounded-box w-18"  %>
+                    <%= image_tag my_memo.user.profile.image, class: "rounded-box", size: "70x70"  %>
                   <% else %>
-                    <%= image_tag "アイコン_デフォルト.png", class: "rounded-box w-18" %>
+                    <%= image_tag "アイコン_デフォルト.png", class: "rounded-box", size: "70x70" %>
                   <% end %>
                 </div>
-                <div class="w-full md:flex md:flex-row">
-                  <div class="md:flex md:flex-row md:items-center md:justify-center md:space-x-10 w-full md:w-1/2">
-                    <div class="uppercase font-semibold opacity-60 md:text-2xl"><%= my_memo[:artist_name] %> <br> <%= my_memo[:song_title] %></div>
+                <div class="w-full md:flex md:flex-row md:justify-between">
+                  <div class="">
+                    <div class="uppercase font-semibold opacity-60 md:text-2xl md:text-start md:ml-5"><%= my_memo[:artist_name] %></div>
+                    <div class="uppercase font-semibold opacity-60 md:text-2xl md:text-start md:ml-5"><%= my_memo[:song_title] %></div>
                   </div>
                   <div class="flex flex-row items-center justify-center space-x-1 md:space-x-5">
                     <% if my_memo.publish %>
@@ -40,7 +41,7 @@
             method: :delete,
             data: { confirm: "本当に削除しますか？", method: "delete" , turbo: false},
             class: "w-10 h-10 bg-red-700 text-white rounded-full flex items-center justify-center shadow-md inline-block" do %>
-            <i class="fas fa-trash text-2xl p-3 md:text-5xl"></i>
+            <i class="fas fa-trash text-2xl p-3 md:text-3xl"></i>
           <% end %>
         </div>
 


### PR DESCRIPTION
## 概要
- 新着メモ一覧、マイメモ一覧、ハッシュタグのバグを修正しました。

## 変更内容
- **修正**: 新着メモ一覧のレイアウトを修正
- **修正**: マイメモ一覧のレイアウトを修正
- **修正**: ハッシュタグのレイアウトを修正

## 動作確認方法
1. **Renderコンソール**
   - [x] エラーが出ていないことを確認
2. **ステージング環境**
   - [x] エラーが出ていないことを確認

## 関連Issue
- #170 

## スクリーンショット
- iPhoneSE（ステージング環境）
![utamemo jp_users_1_profile_my_memos(PC(1280px))](https://github.com/user-attachments/assets/3f4c0110-c46c-47f9-a08b-e6d35bb46c17)
![utamemo jp_memos(PC(1280px))](https://github.com/user-attachments/assets/170132f9-d177-4c36-8e8e-9cde791b41b9)

## 参考資料
- issueに記載

## 備考
