### PR TITLE
fix:新着メモ一覧修正 [render preview]

### DIFF
--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -5,7 +5,7 @@
     <div class="items-center w-[330px] md:w-[800px] mx-auto">
       <%= button_to memo_path(memo.id), { method: :get, class: "w-full mx-auto bg-base-100 rounded-box shadow-md p-4" } do %>    
         <div class="flex flex-row items-center justify-between">
-          <div class="flex flex-row items-center md:space-x-10">
+          <div class="flex flex-row items-center space-x-2 md:space-x-10 w-[250px]">
             <div>
               <% if memo.user.profile&.image&.attached? %>
                 <%= image_tag memo.user.profile.image, size: "70x70", class: "rounded-box" %>
@@ -14,7 +14,7 @@
               <% end %>
             </div>
             <div class="md:flex md:flex-row md:items-center">
-              <div class="text-xl font-bold md:text-2xl w-[250px] text-start"><%= memo.user.nickname %></div>
+              <div class="text-xl font-bold md:text-2xl text-start"><%= memo.user.nickname %></div>
               <div>
                 <div class="uppercase font-semibold opacity-60 md:text-2xl text-start"><%= memo[:artist_name] %></div>
                 <div class="uppercase font-semibold opacity-60 md:text-2xl text-start"><%= memo[:song_title] %></div>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -5,7 +5,7 @@
     <div class="items-center w-[330px] md:w-[800px] mx-auto">
       <%= button_to memo_path(memo.id), { method: :get, class: "w-full mx-auto bg-base-100 rounded-box shadow-md p-4" } do %>    
         <div class="flex flex-row items-center justify-between">
-          <div class="flex flex-row items-center space-x-2 md:space-x-10 w-[250px]">
+          <div class="flex flex-row items-center space-x-2 md:space-x-10 w-[250px] md:w-full">
             <div>
               <% if memo.user.profile&.image&.attached? %>
                 <%= image_tag memo.user.profile.image, size: "70x70", class: "rounded-box" %>
@@ -14,7 +14,7 @@
               <% end %>
             </div>
             <div class="md:flex md:flex-row md:items-center">
-              <div class="text-xl font-bold md:text-2xl text-start"><%= memo.user.nickname %></div>
+              <div class="text-xl font-bold md:text-2xl text-start md:w-[250px]"><%= memo.user.nickname %></div>
               <div>
                 <div class="uppercase font-semibold opacity-60 md:text-2xl text-start"><%= memo[:artist_name] %></div>
                 <div class="uppercase font-semibold opacity-60 md:text-2xl text-start"><%= memo[:song_title] %></div>


### PR DESCRIPTION
## 概要
- 新着メモ一覧のレイアウト崩れを修正しました

## 変更内容
- **修正**: memos/index.html.erbを修正

## 動作確認方法
1. **Renderコンソール**
   - [x] エラーが出ていないことを確認
2. **ステージング環境**
   - [x] エラーが出ていないことを確認

## 関連Issue
- #170 

## スクリーンショット
- PC画面
![utamemo-pr-176 onrender com_memos(PC(1280px))](https://github.com/user-attachments/assets/7562a89a-9caf-42da-b38d-e0f7b30f3ae5)

## 参考資料
- issueに記載

## 備考
