### PR TITLE
fix:レイアウト調整[render preview] 

### DIFF
--- a/app/javascript/components/MyMemos.jsx
+++ b/app/javascript/components/MyMemos.jsx
@@ -301,7 +301,7 @@ export default function MyMemos({ memo }) {
             {/* ツールバー（コメント） */}
             <div className="flex flex-row justify-center space-x-2 hidden pb-2 w-[350px]" id="comment">
               <input 
-                className="w-[85%] border border-pink-600 bg-slate-950 border-2 rounded-lg p-1 text-white"
+                className="w-[85%] border bg-slate-950 border-2 rounded-lg p-1 text-white"
                 ref={commentButtonRef} 
                 id="comment_input"
                 placeholder="   コメントを入力"/>

--- a/app/javascript/components/MyMemos.jsx
+++ b/app/javascript/components/MyMemos.jsx
@@ -278,45 +278,38 @@ export default function MyMemos({ memo }) {
         {/* フラッシュメッセージ */}
         <div id="flash-message" className="hidden p-2 w-full text-white"></div>
 
-        <div className="bg-purple-500 p-2 mb-2 rounded-xl">
-          <div>
+        <div className="bg-purple-500 p-2 flex flex-col justify-center items-center">
             {/* ツールバー（テクニック） */}
-            <div className="flex flex-row justify-center space-x-2 hidden" id="technique">
-              <button onClick={() => addTechniqueComponent(1)} className="flex flex-col justify-center">
+            <div className="flex flex-row justify-between hidden pb-2 w-[350px]" id="technique">
+              <button onClick={() => addTechniqueComponent(1)}>
                 <img src="/technique/ビブラート.png" alt="ビブラート" style={{ width: "50px", height: "50px"}}/>
-                <div className="text-white text-sm">ビブラート</div>
               </button>
-              <button onClick={() => addTechniqueComponent(2)} className="flex flex-col justify-center">
+              <button onClick={() => addTechniqueComponent(2)}>
                 <img src="/technique/しゃくり.png" alt="しゃくり" style={{ width: "50px", height: "50px"}}/>
-                <div className="text-white text-sm">しゃくり</div>
               </button>
-              <button onClick={() => addTechniqueComponent(3)} className="flex flex-col justify-center">
+              <button onClick={() => addTechniqueComponent(3)}>
                 <img src="/technique/こぶし.png" alt="こぶし" style={{ width: "50px", height: "50px"}}/>
-                <div className="text-white text-sm">こぶし</div>
               </button>
-              <button onClick={() => addTechniqueComponent(4)} className="flex flex-col justify-center">
+              <button onClick={() => addTechniqueComponent(4)}>
                 <img src="/technique/フォール.png" alt="フォール" style={{ width: "50px", height: "50px"}}/>
-                <div className="text-white text-sm">フォール</div>
               </button>
-              <button onClick={() => addTechniqueComponent(5)} className="flex flex-col justify-center">
+              <button onClick={() => addTechniqueComponent(5)}>
                 <img src="/technique/ブレス.png" alt="ブレス" style={{ width: "50px", height: "50px"}}/>
-                <div className="text-white text-sm">ブレス</div>
               </button>
             </div>
 
             {/* ツールバー（コメント） */}
-            <div className="flex flex-row justify-center space-x-2 hidden" id="comment">
+            <div className="flex flex-row justify-center space-x-2 hidden pb-2 w-[350px]" id="comment">
               <input 
-                className="w-[85%] border border-gray-400 rounded-lg p-1"
+                className="w-[85%] border border-pink-600 bg-slate-950 border-2 rounded-lg p-1 text-white"
                 ref={commentButtonRef} 
                 id="comment_input"
                 placeholder="   コメントを入力"/>
-              <button onClick={addCommentComponent} className="btn">コメント<br/>追加</button>
+              <button onClick={addCommentComponent} className="btn">追加</button>
             </div>
-          </div>
 
           {/* ツールバー  */}
-          <div className="pt-1 flex flex-row justify-center space-x-2" >
+          <div className="flex flex-row justify-between space-x-2 w-[350px]" >
             <button
               className="btn bg-gray-300"
               ref={techniqueButtonRef} 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,7 +46,7 @@
     <script src="https://kit.fontawesome.com/58f012fe42.js" crossorigin="anonymous"></script>
   </head>
 
-  <body class="flex flex-col min-h-screen bg-zinc-700">
+  <body class="flex flex-col min-h-dvh bg-zinc-700">
     
     <%= render "shared/header" %>
     <%= render "shared/flash" %>

--- a/app/views/memos/_lyrics.html.erb
+++ b/app/views/memos/_lyrics.html.erb
@@ -12,9 +12,8 @@
       ライセンスの関係で、歌詞の取得がここまでしかできません。
     </div>
   <% else %>
-    <div class="p-4 text-white">
-      歌詞取得エラーが発生しました。
-      管理者までお問い合わせをお願いします。
+    <div class="p-4 text-white text-center">
+      アクセスできませんでした。
     </div>
   <% end %>
 </turbo-frame>

--- a/app/views/memos/_lyrics.html.erb
+++ b/app/views/memos/_lyrics.html.erb
@@ -1,9 +1,8 @@
-<turbo-frame id="lyrics">
+<turbo-frame id="lyrics"">
   <% if lyrics_result && !!lyrics_result.split(/\*{7,}/).first %>
     <% lyrics_result = (lyrics_result.split(/\*{7,}/).first.strip) %>
     <div class="flex">
-      <div class="mx-5 mt-10 mb-10 pt-10 text-white text-2xl">
-
+      <div class="mx-5 mt-10 mb-10 pt-10 text-white text-2xl max-w-[335px]">
         <%= simple_format(h(lyrics_result.gsub(/\n/,'<br><br><br><br><br>').html_safe)) %>
       </div>
     </div>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -1,11 +1,10 @@
 <% provide(:title, "#{@memo[:song_title]} | UTAMEMO")%>
-<div class="flex flex-col items-center text-white bg-purple-500 p-2 text-center rounded-full">
-  <div class="font-bold space-x-2 text-lg">
-    <%= @memo[:artist_name] %>  /  <%= @memo[:song_title] %>
-  </div>
+<div class="flex flex-col items-center text-white bg-purple-500 p-2 text-center">
+  <div class="font-bold text-lg"><%= @memo[:artist_name] %></div>
+  <div class="font-bold text-lg"><%= @memo[:song_title] %></div>
   <div class="flex flex-col items-center">
     <div>created_by: <%= @memo.user[:nickname] %></div>
-    <div class="mt-2 flex flex-row space-x-2 items-center">
+    <div class="mt-2 flex flex-row space-x-10 items-center">
       <% if @memo.publish %>
         <% twitter_share_url = 
           "https://twitter.com/intent/tweet?url=#{URI.encode_www_form_component(memo_url(@memo))}&text=#{@memo.user.nickname}さんのUTAMEMO！&hashtags=#{remove_invalid_chars(@memo[:artist_name])},#{remove_invalid_chars(@memo[:song_title])},UTAMEMO" %>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -3,7 +3,7 @@
   <div class="font-bold text-lg"><%= @memo[:artist_name] %></div>
   <div class="font-bold text-lg"><%= @memo[:song_title] %></div>
   <div class="flex flex-col items-center">
-    <div>created_by: <%= @memo.user[:nickname] %></div>
+    <div class="text-sm">created_by: <%= @memo.user[:nickname] %></div>
     <div class="mt-2 flex flex-row space-x-10 items-center">
       <% if @memo.publish %>
         <% twitter_share_url = 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,9 +1,10 @@
 <header class="p-4 bg-slate-950 sticky top-0 z-50 flex justify-between items-center pb-2">
   <!-- オーバーレイ --> 
   <div id="menu-overlay" class="fixed inset-0 bg-black opacity-0 pointer-events-none transition-opacity duration-200"></div>
-  <div class="inline-block text-3xl font-bold text-pink-500 ">
-    <%= link_to "UTAMEMO", root_path %>
+  <div class="inline-block text-3xl font-bold">
+    <%= link_to "UTAMEMO", root_path, class: "text-pink-500 hover:bg-slate-800 rounded-full p-2 duration-200 block active:rotate-2" %>
   </div>
+
   <!-- メニューボタンと検索アイコン -->
   <div class="relative items-center flex">
     <div class="flex justify-end">
@@ -49,21 +50,11 @@
         
         <!-- メニューアイコン -->
         <button
-          class="btn bg-blue-500 text-white rounded-lg px-4 py-2 block"
+          class="btn bg-blue-500 hover:bg-blue-600 text-white rounded-lg px-4 py-2 block"
           id="menu-button"
         >
           ☰
         </button>
-        <!-- アカウント名 -->
-        <div>
-          <% if user_signed_in? %>
-            <div class="text-sm text-pink-500 font-bold" %>
-              <%= current_user.nickname %> さん
-            </div>
-          <% else %>
-            <div class="text-sm text-pink-500 font-bold">ゲスト さん</div>
-          <% end %>
-        </div>
       </div>
     </div>
 
@@ -73,9 +64,11 @@
       id="menu-content"
     >
       <% if user_signed_in? %>
+        <li><div class="text-lg text-white font-bold" %><%= current_user.nickname %> さん</div></li>
         <li><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete}, class: "block px-4 py-2 hover:bg-blue-600" %></li>
         <li><%= link_to "マイページ", user_profile_path(current_user.id), class: "block px-4 py-2 hover:bg-blue-600" %></li>
       <% else %>
+        <li><div class="text-lg text-white font-bold">ゲスト さん</div></li>
         <li><%= link_to "ログイン", new_user_session_path, class: "block px-4 py-2 hover:bg-blue-600" %></li>
         <li><%= link_to "新規会員登録", new_user_registration_path, class: "block px-4 py-2 hover:bg-blue-600" %></li>
       <% end %>


### PR DESCRIPTION
## 概要
- 全体的にレイアウトを調整しました。

## 変更内容
- **修正**: application.html.erbでmin-h-screenをmin-h-dvhに変更
- **修正**: 歌詞が見つからなかった時の表示内容を変更
- **修正**: メモのshowページでアーティストと曲名を2行に変更
- **修正**: ヘッダーのロゴをhoverとactiveを追加
- **修正**: 名前をハンバーガーメニュー内に移動

## 動作確認方法
1. **Renderコンソール**
   - [x] エラーが出ていないことを確認
2. **ステージング環境**
   - [x] エラーが出ていないことを確認

## 関連Issue
- #184 

## スクリーンショット
- iPhoneSE（ステージング環境）メモ作成画面でロゴのアクティブ状態
![image](https://github.com/user-attachments/assets/527094b1-5c52-4fdf-9be7-6a24ee3909a6)

## 参考資料
- issueに記載

## 備考
