### PR TITLE
歌詞取得部分のタイポを修正

### DIFF
--- a/app/views/memos/_lyrics.html.erb
+++ b/app/views/memos/_lyrics.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="lyrics"">
+<turbo-frame id="lyrics">
   <% if lyrics_result && !!lyrics_result.split(/\*{7,}/).first %>
     <% lyrics_result = (lyrics_result.split(/\*{7,}/).first.strip) %>
     <div class="flex">


### PR DESCRIPTION
## 概要
- 歌詞取得部分のタイポを修正しました。

## 変更内容
- **修正**: 余分な"を削除

## 動作確認方法
1. **Renderコンソール**
   - [x] エラーが出ていないことを確認
2. **ステージング環境**
   - [x] エラーが出ていないことを確認

## 関連Issue
- #

## スクリーンショット
- iPhoneSE（ステージング環境）

## 参考資料
- issueに記載

## 備考
