### PR TITLE
fix:外部APIフェッチでstandard errorをキャッチする処理を追加[render preview]

### DIFF
--- a/app/services/lyrics_fetcher.rb
+++ b/app/services/lyrics_fetcher.rb
@@ -3,13 +3,18 @@
 class LyricsFetcher
   # キーワード引数で受け取っている。ハッシュの形で引数を渡せる。
   def self.call(api_key:, q_track:, q_artist:)
-    lyrics_encoded_uri = URI::DEFAULT_PARSER.escape("https://api.musixmatch.com/ws/1.1/matcher.lyrics.get?apikey=#{api_key}&q_track=#{q_track}&q_artist=#{q_artist}")
-    lyrics_response = HTTParty.get(lyrics_encoded_uri)
-    lyrics_response_code_check = JSON.parse(lyrics_response)
-    Rails.logger.debug { "lyrics_response: #{JSON.pretty_generate(lyrics_response_code_check)}" }
-    return nil if lyrics_response_code_check['message']['header']['status_code'] == 404
 
-    parsed_json_lyrics_response = JSON.parse(lyrics_response)
-    parsed_json_lyrics_response['message']['body']['lyrics']['lyrics_body']
+    begin
+      lyrics_encoded_uri = URI::DEFAULT_PARSER.escape("https://api.musixmatch.com/ws/1.1/matcher.lyrics.get?apikey=#{api_key}&q_track=#{q_track}&q_artist=#{q_artist}")
+      lyrics_response = HTTParty.get(lyrics_encoded_uri)
+      lyrics_response_code_check = JSON.parse(lyrics_response)
+      Rails.logger.debug { "lyrics_response: #{JSON.pretty_generate(lyrics_response_code_check)}" }
+      return nil if lyrics_response_code_check['message']['header']['status_code'] == 404
+      parsed_json_lyrics_response = JSON.parse(lyrics_response)
+      parsed_json_lyrics_response['message']['body']['lyrics']['lyrics_body']
+
+    rescue StandardError => e
+      Rails.logger.error("standard error: #{e.message}")
+      nil
   end
 end

--- a/app/services/lyrics_fetcher.rb
+++ b/app/services/lyrics_fetcher.rb
@@ -3,18 +3,16 @@
 class LyricsFetcher
   # キーワード引数で受け取っている。ハッシュの形で引数を渡せる。
   def self.call(api_key:, q_track:, q_artist:)
+    lyrics_encoded_uri = URI::DEFAULT_PARSER.escape("https://api.musixmatch.com/ws/1.1/matcher.lyrics.get?apikey=#{api_key}&q_track=#{q_track}&q_artist=#{q_artist}")
+    lyrics_response = HTTParty.get(lyrics_encoded_uri)
+    lyrics_response_code_check = JSON.parse(lyrics_response)
+    Rails.logger.debug { "lyrics_response: #{JSON.pretty_generate(lyrics_response_code_check)}" }
+    return nil if lyrics_response_code_check['message']['header']['status_code'] == 404
 
-    begin
-      lyrics_encoded_uri = URI::DEFAULT_PARSER.escape("https://api.musixmatch.com/ws/1.1/matcher.lyrics.get?apikey=#{api_key}&q_track=#{q_track}&q_artist=#{q_artist}")
-      lyrics_response = HTTParty.get(lyrics_encoded_uri)
-      lyrics_response_code_check = JSON.parse(lyrics_response)
-      Rails.logger.debug { "lyrics_response: #{JSON.pretty_generate(lyrics_response_code_check)}" }
-      return nil if lyrics_response_code_check['message']['header']['status_code'] == 404
-      parsed_json_lyrics_response = JSON.parse(lyrics_response)
-      parsed_json_lyrics_response['message']['body']['lyrics']['lyrics_body']
-
-    rescue StandardError => e
-      Rails.logger.error("standard error: #{e.message}")
-      nil
+    parsed_json_lyrics_response = JSON.parse(lyrics_response)
+    parsed_json_lyrics_response['message']['body']['lyrics']['lyrics_body']
+  rescue StandardError => e
+    Rails.logger.error("standard error: #{e.message}")
+    nil
   end
 end

--- a/app/services/track_fetcher.rb
+++ b/app/services/track_fetcher.rb
@@ -3,17 +3,15 @@
 class TrackFetcher
   # キーワード引数で受け取っている。ハッシュの形で引数を渡せる。
   def self.call(api_key:, q_track:, q_artist:)
-    begin
-      track_encoded_uri = URI::DEFAULT_PARSER.escape("https://api.musixmatch.com/ws/1.1/matcher.track.get?apikey=#{api_key}&q_track=#{q_track}&q_artist=#{q_artist}")
-      track_response = HTTParty.get(track_encoded_uri)
-      track_response_code_check = JSON.parse(track_response)
-      return nil if track_response_code_check['message']['header']['status_code'] == 404
+    track_encoded_uri = URI::DEFAULT_PARSER.escape("https://api.musixmatch.com/ws/1.1/matcher.track.get?apikey=#{api_key}&q_track=#{q_track}&q_artist=#{q_artist}")
+    track_response = HTTParty.get(track_encoded_uri)
+    track_response_code_check = JSON.parse(track_response)
+    return nil if track_response_code_check['message']['header']['status_code'] == 404
 
-      parsed_json_track_response = JSON.parse(track_response)
-      parsed_json_track_response['message']['body']['track'].slice('track_name', 'artist_name')
-    rescue StandardError => e
-      Rails.logger.error("standard error: #{e.message}")
-      nil
-    end
+    parsed_json_track_response = JSON.parse(track_response)
+    parsed_json_track_response['message']['body']['track'].slice('track_name', 'artist_name')
+  rescue StandardError => e
+    Rails.logger.error("standard error: #{e.message}")
+    nil
   end
 end

--- a/app/services/track_fetcher.rb
+++ b/app/services/track_fetcher.rb
@@ -3,12 +3,17 @@
 class TrackFetcher
   # キーワード引数で受け取っている。ハッシュの形で引数を渡せる。
   def self.call(api_key:, q_track:, q_artist:)
-    track_encoded_uri = URI::DEFAULT_PARSER.escape("https://api.musixmatch.com/ws/1.1/matcher.track.get?apikey=#{api_key}&q_track=#{q_track}&q_artist=#{q_artist}")
-    track_response = HTTParty.get(track_encoded_uri)
-    track_response_code_check = JSON.parse(track_response)
-    return nil if track_response_code_check['message']['header']['status_code'] == 404
+    begin
+      track_encoded_uri = URI::DEFAULT_PARSER.escape("https://api.musixmatch.com/ws/1.1/matcher.track.get?apikey=#{api_key}&q_track=#{q_track}&q_artist=#{q_artist}")
+      track_response = HTTParty.get(track_encoded_uri)
+      track_response_code_check = JSON.parse(track_response)
+      return nil if track_response_code_check['message']['header']['status_code'] == 404
 
-    parsed_json_track_response = JSON.parse(track_response)
-    parsed_json_track_response['message']['body']['track'].slice('track_name', 'artist_name')
+      parsed_json_track_response = JSON.parse(track_response)
+      parsed_json_track_response['message']['body']['track'].slice('track_name', 'artist_name')
+    rescue StandardError => e
+      Rails.logger.error("standard error: #{e.message}")
+      nil
+    end
   end
 end


### PR DESCRIPTION
## 概要
- 外部APIフェッチでstandard errorをキャッチする処理を追加

## 変更内容
- **修正**: 外部APIフェッチでstandard errorをキャッチする処理を追加(app/services/lyrics_fetcher.rb,app/services/track_fetcher.rb)

## 動作確認方法
1. **Renderコンソール**
   - [x] エラーが出ていないことを確認
2. **ステージング環境**
   - [x] エラーが出ていないことを確認
   - [x] Railsのエラーが出ずにユーザーにメッセージを表示していることを確認 

## スクリーンショット
- iPhoneSE（ステージング環境）

## 参考資料
- issueに記載

## 備考
