### PR TITLE
fix:新着メモ一覧の画像を丸く修正

### DIFF
--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -8,9 +8,9 @@
           <div class="flex flex-row items-center space-x-2 md:space-x-10 w-[250px] md:w-full">
             <div>
               <% if memo.user.profile&.image&.attached? %>
-                <%= image_tag memo.user.profile.image, size: "70x70", class: "rounded-box" %>
+                <%= image_tag memo.user.profile.image, size: "70x70", class: "rounded-full" %>
               <% else %>
-                <%= image_tag "アイコン_デフォルト.png", size: "70x70", class: "rounded-box" %>
+                <%= image_tag "アイコン_デフォルト.png", size: "70x70", class: "rounded-full" %>
               <% end %>
             </div>
             <div class="md:flex md:flex-row md:items-center">


### PR DESCRIPTION
## 概要
- 新着メモ一覧の画像を丸く修正しました

## 変更内容
- **修正**: 新着メモ一覧の画像を丸く修正しました
app/views/memos/index.html.erb

## 動作確認方法
1. **Renderコンソール**
   - [x] エラーが出ていないことを確認
2. **ステージング環境**
   - [x] エラーが出ていないことを確認
