### PR TITLE
add:メモテーブルの第三正規化②カラム削除のマイグレーションを追加

### DIFF
--- a/db/migrate/20250509010840_remove_song_title_and_artist_name_from_memos.rb
+++ b/db/migrate/20250509010840_remove_song_title_and_artist_name_from_memos.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class RemoveSongTitleAndArtistNameFromMemos < ActiveRecord::Migration[7.2]
+  # ロールバック時にリカバリ出来るようにupとdownで記載
+  def up
+    change_table :memos, bulk: true do |t|
+      t.remove :artist_name
+      t.remove :song_title
+    end
+  end
+
+  def down
+    change_table :memos, bulk: true do |t|
+      t.string :artist_name
+      t.string :song_title
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- カラム削除のマイグレーションを追加

## 変更内容
- **新規追加**: memoテーブルから不要カラム（artist_name、song_title）を削除するマイグレーションを追加

## 動作確認方法
1. **Renderコンソール**
   - [x] エラーが出ていないことを確認
2. **ステージング環境**
   - [x] エラーが出ていないことを確認

## 関連Issue
- #213 

## スクリーンショット
- iPhoneSE（ステージング環境）

## 参考資料
- issueに記載

## 備考
